### PR TITLE
import gov.nasa.jpf.jvm.Verify instead of gov.nasa.jpf.vm.Verify

### DIFF
--- a/Environment.java
+++ b/Environment.java
@@ -1,4 +1,4 @@
-import gov.nasa.jpf.vm.Verify;
+import gov.nasa.jpf.jvm.Verify;
 
 class Environment {
   public final static int N_THREADS = 3;


### PR DESCRIPTION
Had to tweak an import an import statement in order to get `./compile.sh` to build the project. This is probably just a peculiarity with the specific JDK and JPF snapshot I'm using (and as such I don't think this PR should be merged), but I'm leaving this here for anyone that runs into something like the following trace when running `./compile.sh`:

`Diagnostics.java:3: error: package gov.nasa.jpf.vm does not exist`

I'm using the latest JPF snapshot found [here](http://babelfish.arc.nasa.gov/trac/jpf/wiki/projects/jpf-core#no1) and the following JDK version:

```
[~/projects/jpf/lock-model]{master*} $ javac -version
javac 1.7.0_79
```
